### PR TITLE
fix: missing metadata when building wheel from sdist

### DIFF
--- a/src/mina_backend/hooks.py
+++ b/src/mina_backend/hooks.py
@@ -14,9 +14,10 @@ else:
     from pdm.backend._vendor import tomli
 
 
-def _mina_enabled(context: Context) -> bool:
+def pdm_build_hook_enabled(context: Context) -> bool:
     tool_mina = context.config.data.get("tool", {}).get("mina", {})
     return bool(tool_mina.get("enabled"))
+
 
 def _get_build_target(context: Context) -> str | None:
     tool_mina = context.config.data.get("tool", {}).get("mina", {})
@@ -99,11 +100,13 @@ def deep_merge(source: MutableMapping, target: Mapping) -> Mapping:
 
 
 def pdm_build_initialize(context: Context) -> None:
-    if not _mina_enabled(context):
+    if not pdm_build_hook_enabled(context):
         return
 
     mina_target = _get_build_target(context)
     if mina_target is None:
         return
-    
+
     _update_config(context.config, mina_target)
+    # Disable mina after update
+    context.config.data.setdefault("tool", {}).setdefault("mina", {})["enabled"] = False


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

PyPA [build] project builds the wheel from the result sdist, whose metadata has been updated. This can result in a missing metadata since the package metadata can be removed when updating.

This patch fixes the issue by disabling the mina hook after udpate is done. So subsequent builds which read the updated pyproject.toml won't call mina hook anymore.

[build]: https://github.com/pypa/build